### PR TITLE
Pass keyEncoding on to subs

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = class SubEncoder {
 
   sub (prefix, opts) {
     return new SubEncoder(prefix, {
+      keyEncoding: this.userEncoding,
       ...opts,
       _parent: this.prefix,
       _sub: true

--- a/test/all.js
+++ b/test/all.js
@@ -160,6 +160,25 @@ test('can read out the empty key in subs', async t => {
   t.alike(n3[0].key, b.alloc(1))
 })
 
+test('keyEncoding is passed to subs as default', async t => {
+  const bee = new Hyperbee(new Hypercore(ram))
+  const enc = new SubEncoder({ keyEncoding: 'utf-8' })
+
+  const sub = enc.sub('mySub')
+
+  await bee.put('I am text', 'not buffer', { keyEncoding: sub })
+
+  const entry = await bee.get('I am text', { keyEncoding: sub })
+  t.is(entry.key, 'I am text')
+
+  // But default can be overriden
+  const bufferSub = enc.sub('otherSub', { keyEncoding: 'binary' })
+  await bee.put('I am buffer', '(overriden)', { keyEncoding: bufferSub })
+
+  const bufferEntry = await bee.get('I am buffer', { keyEncoding: bufferSub })
+  t.alike(bufferEntry.key, b.from('I am buffer'))
+})
+
 async function collect (ite) {
   const res = []
   for await (const node of ite) {


### PR DESCRIPTION
Note: non-trival flow for passing it through to the sub, since the `userEncoding` is the result of `codecs(opts && opts.keyEncoding)`, so to the subs we are passing an instance of codecs instead of the original keyEncoding.
This means the sub will once again call codecs on that codecs-instance, but I think that's fine (it will just return that same instance, because it has an encode and decode method)