### PR TITLE
Bugfix: init with prefix adds SEP

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ const SEP_BUMPED = b.from([0x1])
 module.exports = class SubEncoder {
   constructor (prefix, encoding) {
     this.userEncoding = codecs(encoding)
-    this.prefix = typeof prefix === 'string' ? b.from(prefix) : (prefix || null)
+
+    if (typeof prefix === 'string') prefix = b.from(prefix)
+    this.prefix = prefix ? b.concat([prefix, SEP]) : null
+
     this.lt = this.prefix && b.concat([this.prefix.subarray(0, this.prefix.byteLength - 1), SEP_BUMPED])
   }
 
@@ -55,10 +58,10 @@ module.exports = class SubEncoder {
 }
 
 function createPrefix (prefix, parent) {
-  if (prefix && parent) return b.concat([parent, prefix, SEP])
-  if (prefix) return b.concat([prefix, SEP])
-  if (parent) return b.concat([parent, SEP])
-  return SEP
+  if (prefix && parent) return b.concat([parent, prefix])
+  if (prefix) return prefix
+  if (parent) return parent
+  return b.alloc(0)
 }
 
 function compat (enc) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const b = require('b4a')
 
 const SEP = b.alloc(1)
 const SEP_BUMPED = b.from([0x1])
+const EMPTY = b.alloc(0)
 
 module.exports = class SubEncoder {
   constructor (prefix, encoding, parent = null) {
@@ -49,10 +50,7 @@ module.exports = class SubEncoder {
   }
 
   sub (prefix, encoding) {
-    // Differentiate empty sub on existing subEncoder from new empty subEncoder
-    if (prefix == null) prefix = b.alloc(0)
-
-    return new SubEncoder(prefix, compat(encoding), this.prefix)
+    return new SubEncoder(prefix || EMPTY, compat(encoding), this.prefix)
   }
 }
 

--- a/test/all.js
+++ b/test/all.js
@@ -140,6 +140,38 @@ test('supports the empty sub', async t => {
   t.alike(n3[0].key, b.alloc(1))
 })
 
+test('supports the empty sub on top of another sub', async t => {
+  const bee = new Hyperbee(new Hypercore(ram))
+  const enc = new SubEncoder()
+
+  const sub1 = enc.sub('1', 'utf-8')
+  const subSubEmpty = sub1.sub()
+  const subSub1 = sub1.sub('not empty', 'utf-8')
+
+  await bee.put('', 'sub1 Entry', { keyEncoding: sub1 })
+  await bee.put('', 'subSub1 Entry', { keyEncoding: subSub1 })
+  await bee.put(b.alloc(1), 'EmptySubsub entry', { keyEncoding: subSubEmpty })
+
+  const n3 = await collect(bee.createReadStream({ keyEncoding: subSubEmpty }))
+
+  t.is(n3.length, 1)
+  t.alike(n3[0].key, b.alloc(1))
+})
+
+test('empty str is a valid prefix, causing no overlap', async t => {
+  const bee = new Hyperbee(new Hypercore(ram))
+  const enc = new SubEncoder()
+
+  const sub1 = enc.sub('', 'utf-8')
+  const sub2 = enc.sub('other', 'utf-8')
+
+  await bee.put('hey', 'ho', { keyEncoding: sub1 })
+  await bee.put('not', 'a part', { keyEncoding: sub2 })
+  const res = await collect(bee.createReadStream({ keyEncoding: sub1 }))
+  t.is(res.length, 1)
+  t.alike(res[0].key, 'hey')
+})
+
 test('can read out the empty key in subs', async t => {
   const bee = new Hyperbee(new Hypercore(ram))
   const enc = new SubEncoder()

--- a/test/all.js
+++ b/test/all.js
@@ -188,6 +188,12 @@ test('sub + index + hyperbee combo', async t => {
   t.is(expectedKeys.length, 0)
 })
 
+test('constructor-specified sub equivalent to calling .sub()', async t => {
+  const directSub = new SubEncoder('mysub', 'utf-8')
+  const roundaboutSub = (new SubEncoder()).sub('mysub', 'utf-8')
+  t.alike(directSub, roundaboutSub)
+})
+
 async function collect (ite) {
   const res = []
   for await (const node of ite) {


### PR DESCRIPTION
Creating a new SubEncoder with an initial sub did not work correctly, because the SEP was not added at the end.

Previously, the code assumed implicitly that `new SubEncoder(...)` was called from `createPrefix`, which adds the SEP. The fix instead adds the SEP in the constructor itself.