### PR TITLE
Bugfix: encode falsy values

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,13 @@ module.exports = class SubEncoder {
   _encodeRangeUser (r) {
     if (this.userEncoding.encodeRange) return this.userEncoding.encodeRange(r)
 
-    return {
-      gt: r.gt && this.userEncoding.encode(r.gt),
-      gte: r.gte && this.userEncoding.encode(r.gte),
-      lte: r.lte && this.userEncoding.encode(r.lte),
-      lt: r.lt && this.userEncoding.encode(r.lt)
-    }
+    const res = {}
+    if (r.gt !== undefined) res.gt = this.userEncoding.encode(r.gt)
+    if (r.gte !== undefined) res.gte = this.userEncoding.encode(r.gte)
+    if (r.lte !== undefined) res.lte = this.userEncoding.encode(r.lte)
+    if (r.lt !== undefined) res.lt = this.userEncoding.encode(r.lt)
+
+    return res
   }
 
   _addPrefix (key) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/holepunchto/sub-encoder#readme",
   "devDependencies": {
     "brittle": "^3.1.1",
+    "compact-encoding": "^2.12.0",
     "hyperbee": "^2.11.0",
     "hypercore": "^10.3.2",
     "index-encoder": "^3.0.0",


### PR DESCRIPTION
See the newly-added test for an example where current main fails (using lexints and then encoding '0')

I also refactored the `_encodeRangeUser` method so it no longer returns something of form
```
{ lt: false, gt: false, lte: <buffer>, lt: false}
```
instead returning:
```
{ lte: <buffer>}
```
which seems like a cleaner contract

Note: the `encodeRange` method also relies on falsy values, but I think there it's okay because it's supposed to always work with buffers, and `if(<buffer>)` is never false. Willing to make the checks there of type `!== undefined` too though